### PR TITLE
Fix PlayLayer

### DIFF
--- a/src/PlayLayer.cpp
+++ b/src/PlayLayer.cpp
@@ -77,14 +77,14 @@ struct PlayLayerIDs : Modify<PlayLayerIDs, PlayLayer> {
         }
 
         // Provide ids for new nodes
-        #if GEODE_COMP_GD_VERSION <= 22000
-            const size_t expectedSize = 4;
+        #if GEODE_COMP_GD_VERSION == 22000
+            bool isSizeCorrect = newNodes.size() == 3 || newNodes.size() == 4;
         #else
-            const size_t expectedSize = 3;
+            bool isSizeCorrect = newNodes.size() == 3;
         #endif
 
         // Shouldn't be false, but just in case
-        if (newNodes.size() == expectedSize) {
+        if (isSizeCorrect) {
             auto debugText = typeinfo_cast<CCLabelBMFont*>(newNodes[0]);
             auto progressBar = typeinfo_cast<CCSprite*>(newNodes[1]);
             auto timeOrPercentageLabel = typeinfo_cast<CCLabelBMFont*>(newNodes[2]);

--- a/src/PlayLayer.cpp
+++ b/src/PlayLayer.cpp
@@ -25,6 +25,10 @@ $register_ids(PlayLayer) {
     else {
         setIDSafe<CCLabelBMFont>(this, 1, "percentage-label");
     }
+
+#if GEODE_COMP_GD_VERSION == 22000
+    setIDSafe<CCLabelBMFont>(this, 2, "testmode-label");
+#endif
 }
 
 struct PlayLayerIDs : Modify<PlayLayerIDs, PlayLayer> {

--- a/src/PlayLayer.cpp
+++ b/src/PlayLayer.cpp
@@ -101,8 +101,10 @@ struct PlayLayerIDs : Modify<PlayLayerIDs, PlayLayer> {
             }
 
             #if GEODE_COMP_GD_VERSION == 22000
+            if (newNodes.size() == 4) {
                 auto testModeLabel = typeinfo_cast<CCLabelBMFont*>(newNodes[3]);
                 if (testModeLabel) testModeLabel->setID("testmode-label");
+            }
             #endif
         }
     }

--- a/src/PlayLayer.cpp
+++ b/src/PlayLayer.cpp
@@ -38,8 +38,8 @@ struct PlayLayerIDs : Modify<PlayLayerIDs, PlayLayer> {
             log::warn("Failed to set PlayLayer::init hook priority, node IDs may not work properly");
         }
 
-        if (!self.setHookPriority("PlayLayer::showCompleteText", GEODE_ID_PRIORITY)) {
-            log::warn("Failed to set PlayLayer::showCompleteText hook priority, node IDs may not work properly");
+        if (!self.setHookPriority("PlayLayer::setupHasCompleted", GEODE_ID_PRIORITY)) {
+            log::warn("Failed to set PlayLayer::setupHasCompleted hook priority, node IDs may not work properly");
         }
     }
 

--- a/src/PlayLayer.cpp
+++ b/src/PlayLayer.cpp
@@ -18,8 +18,7 @@ $register_ids(PlayLayer) {
     setIDSafe<CCLabelBMFont>(this, 0, "debug-text");
     setIDSafe<CCSprite>(this, 0, "progress-bar");
 
-    auto level = PlayLayer::get()->m_level;
-    if (level->isPlatformer()) {
+    if (this->m_level->isPlatformer()) {
         setIDSafe<CCLabelBMFont>(this, 1, "time-label");
     }
     else {
@@ -32,17 +31,80 @@ $register_ids(PlayLayer) {
 }
 
 struct PlayLayerIDs : Modify<PlayLayerIDs, PlayLayer> {
+    bool m_dontCreateObjects = false;
+
     static void onModify(auto& self) {
         if (!self.setHookPriority("PlayLayer::init", GEODE_ID_PRIORITY)) {
             log::warn("Failed to set PlayLayer::init hook priority, node IDs may not work properly");
         }
+
+        if (!self.setHookPriority("PlayLayer::showCompleteText", GEODE_ID_PRIORITY)) {
+            log::warn("Failed to set PlayLayer::showCompleteText hook priority, node IDs may not work properly");
+        }
     }
 
-    bool init(GJGameLevel* level, bool p1, bool p2) {
-        if (!PlayLayer::init(level, p1, p2)) return false;
+    bool init(GJGameLevel* level, bool useReplay, bool dontCreateObjects) {
+        if (!PlayLayer::init(level, useReplay, dontCreateObjects)) return false;
+
+        // Used in online levels, which delays node creation
+        m_fields->m_dontCreateObjects = dontCreateObjects;
 
         NodeIDs::get()->provide(this);
 
         return true;
     }
+
+    void setupHasCompleted() {
+        // P.S. For some reason, RobTop adds the nodes in this method,
+        // which isn't called from PlayLayer::init if it's an online level
+        if (!m_fields->m_dontCreateObjects)
+            return PlayLayer::setupHasCompleted();
+
+        // Save preinitialized nodes
+        std::unordered_set<cocos2d::CCNode*> nodes;
+        for (auto child : CCArrayExt<CCNode*>(this->getChildren())) {
+            nodes.insert(child);
+        }
+
+        PlayLayer::setupHasCompleted();
+
+        // Filter only new nodes
+        std::vector<cocos2d::CCNode*> newNodes;
+        for (auto child : CCArrayExt<CCNode*>(this->getChildren())) {
+            if (nodes.find(child) == nodes.end()) {
+                newNodes.push_back(child);
+            }
+        }
+
+        // Provide ids for new nodes
+        #if GEODE_COMP_GD_VERSION <= 22000
+            const size_t expectedSize = 4;
+        #else
+            const size_t expectedSize = 3;
+        #endif
+
+        // Shouldn't be false, but just in case
+        if (newNodes.size() == expectedSize) {
+            auto debugText = typeinfo_cast<CCLabelBMFont*>(newNodes[0]);
+            auto progressBar = typeinfo_cast<CCSprite*>(newNodes[1]);
+            auto timeOrPercentageLabel = typeinfo_cast<CCLabelBMFont*>(newNodes[2]);
+
+            if (debugText) debugText->setID("debug-text");
+            if (progressBar) progressBar->setID("progress-bar");
+            if (timeOrPercentageLabel) {
+                if (this->m_level->isPlatformer()) {
+                    timeOrPercentageLabel->setID("time-label");
+                }
+                else {
+                    timeOrPercentageLabel->setID("percentage-label");
+                }
+            }
+
+            #if GEODE_COMP_GD_VERSION == 22000
+                auto testModeLabel = typeinfo_cast<CCLabelBMFont*>(newNodes[3]);
+                if (testModeLabel) testModeLabel->setID("testmode-label");
+            #endif
+        }
+    }
+
 };


### PR DESCRIPTION
- Adds "testmode-label" for macOS ("Testmode" got removed in 2.201)
- Implements ids for percentage, progress bar, debug text for online levels. 

Issue was that RobTop adds the nodes inside PlayLayer::setupHasCompleted(), which isn't called immediately for online levels.