### PR TITLE
Add a layout and a menu to LevelSearchLayer

### DIFF
--- a/src/LevelSearchLayer.cpp
+++ b/src/LevelSearchLayer.cpp
@@ -8,6 +8,9 @@ using namespace geode::node_ids;
 
 $register_ids(LevelSearchLayer) {
     // set the funny ids
+
+    auto winSize = CCDirector::get()->getWinSize();
+
     setIDSafe(this, 0, "background");
     getChildOfType<CCTextInputNode>(this, 0)->setID("search-bar");
     getChildOfType<CCScale9Sprite>(this, 0)->setID("level-search-bg");
@@ -22,9 +25,20 @@ $register_ids(LevelSearchLayer) {
 
     if (auto filtermenu = getChildOfType<CCMenu>(this, 0)) {
         filtermenu->setID("other-filter-menu");
+        filtermenu->setLayout(
+            ColumnLayout::create()
+                ->setAxisReverse(true)
+                ->setGap(10)
+                ->setAxisAlignment(AxisAlignment::End)
+        );
+        filtermenu->setAnchorPoint({1, 0.5f});
+        filtermenu->setPosition({winSize.width - 5, filtermenu->getPositionY()});
+        filtermenu->setContentSize({filtermenu->getContentSize().width, winSize.height-10});
+
         setIDSafe(filtermenu, 0, "clear-filters-button");
         setIDSafe(filtermenu, 1, "advanced-filters-button");
         setIDSafe(filtermenu, 2, "lists-button");
+        filtermenu->updateLayout();
     }
     if (auto searchmenu = getChildOfType<CCMenu>(this, 1)) {
         searchmenu->setID("search-button-menu");
@@ -75,6 +89,19 @@ $register_ids(LevelSearchLayer) {
         backmenu->setID("exit-menu");
         setIDSafe(backmenu, 0, "exit-button");
     }
+
+    auto bottomLeftMenu = CCMenu::create();
+    bottomLeftMenu->setPosition(10, 10);
+    bottomLeftMenu->setID("bottom-left-menu");
+    bottomLeftMenu->setAnchorPoint({0, 0});
+    bottomLeftMenu->setZOrder(1);
+    bottomLeftMenu->setContentSize({ 40.f, winSize.height/2 });
+    bottomLeftMenu->setLayout(
+        ColumnLayout::create()
+            ->setAxisAlignment(AxisAlignment::Start)
+    );
+    this->addChild(bottomLeftMenu);
+
 }
 
 struct LevelSearchLayerIDs : Modify<LevelSearchLayerIDs, LevelSearchLayer> {


### PR DESCRIPTION
This pr adds a layout to "other-filter-menu", the need has came due to multiple mods adding to that menu and conflicting
It also adds a menu for the bottom left, due to a similar issue with conflicting mods positioning their buttons there