### PR TITLE
fix replaceInput not inheriting number input property

### DIFF
--- a/src/SetGroupIDLayer.cpp
+++ b/src/SetGroupIDLayer.cpp
@@ -52,6 +52,7 @@ static void replaceInput(
     // newInput->getInput()->m_maxLabelScale = input->m_maxLabelScale;
     // newInput->getInput()->m_maxLabelLength = input->m_maxLabelLength;
     // newInput->getInput()->m_maxLabelWidth = input->m_maxLabelWidth;
+    newInput->getInputNode()->m_numberInput = input->m_numberInput;
     newInput->setFilter(input->m_allowedChars);
     newInput->setString(input->getString());
     newInput->setDelegate(input->m_delegate, input->getTag());


### PR DESCRIPTION
the inputs in SetGroupIDLayer have `m_numberInput` enabled by default. when node ids replaces an input with a geode input, this value is not inherited. this results in the input not being cleared upon selecting it when its value is 0 or a non-number string like "Mixed," which is mildly annoying. this issue is now fixed

fixes #99