### PR TITLE
fix profilepage side buttons being too close to popup border

### DIFF
--- a/src/ProfilePage.cpp
+++ b/src/ProfilePage.cpp
@@ -66,7 +66,7 @@ $register_ids(ProfilePage) {
             ->setAxisReverse(false)
     );
     leftMenu->setID("left-menu");
-    leftMenu->setPosition({(winSize.width / 2) - 200.f, (winSize.height / 2) + 26.f});
+    leftMenu->setPosition({(winSize.width / 2) - 197.5f, (winSize.height / 2) + 26.f});
     leftMenu->setContentSize({60, 84});
     leftMenu->setZOrder(10);
     m_mainLayer->addChild(leftMenu);
@@ -91,7 +91,7 @@ $register_ids(ProfilePage) {
             ->setAxisReverse(true)
     );
     socialsMenu->setID("socials-menu");
-    socialsMenu->setPosition({(winSize.width / 2) + 200.f, (winSize.height / 2) + 57.75f});
+    socialsMenu->setPosition({(winSize.width / 2) + 197.5f, (winSize.height / 2) + 57.75f});
     socialsMenu->setContentSize({60, 160});
     socialsMenu->setZOrder(10);
     m_mainLayer->addChild(socialsMenu);


### PR DESCRIPTION
minor positioning issue; comment history and social buttons were a little too close to the left and right edges respectively for comfort, so i've moved them both inward a small amount

before:

<img width="3439" height="1439" alt="image" src="https://github.com/user-attachments/assets/fa6af284-f62d-44e1-95bb-d092c535591b" />

after:

<img width="3439" height="1439" alt="image" src="https://github.com/user-attachments/assets/27f0a18b-ce15-47bb-b139-d1a7db2b1aa5" />

vanilla:

<img width="2400" height="1080" alt="image" src="https://github.com/user-attachments/assets/a4c68460-a85a-449b-96b6-9ead257641dc" />