### PR TITLE
GJGarageLayer: fix ignore invisible children on the page arrow menus

### DIFF
--- a/src/GJGarageLayer.cpp
+++ b/src/GJGarageLayer.cpp
@@ -58,7 +58,8 @@ $register_ids(GJGarageLayer) {
                 this,
                 "prev-page-menu",
                 ColumnLayout::create()
-                    ->setAxisAlignment(AxisAlignment::Center),
+                    ->setAxisAlignment(AxisAlignment::Center)
+                    ->ignoreInvisibleChildren(false),
                 prevPageBtn
             );
             prevPageBtn->setZOrder(-1);
@@ -71,7 +72,8 @@ $register_ids(GJGarageLayer) {
                 this,
                 "next-page-menu",
                 ColumnLayout::create()
-                    ->setAxisAlignment(AxisAlignment::Center),
+                    ->setAxisAlignment(AxisAlignment::Center)
+                    ->ignoreInvisibleChildren(false),
                 nextPageBtn
             );
             nextPageBtn->setZOrder(-1);


### PR DESCRIPTION
If the arrows start off as invisible, the layout will not position them properly.
Fix sets ignore invisible children to false on the layout.